### PR TITLE
Add manifest.js to test rails app

### DIFF
--- a/spec/rails_app/app/assets/config/manifest.js
+++ b/spec/rails_app/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link application.css
+//= link application.js


### PR DESCRIPTION
Sprockets now requires a `manifest.js` in order to function properly. See [sprockets/UPGRADING.md](https://github.com/rails/sprockets/blob/070fc01947c111d35bb4c836e9bb71962a8e0595/UPGRADING.md#manifestjs).

This change adds a simple manifest to satisfy that requirement.