### PR TITLE
Fix url encoding issue in test regex

### DIFF
--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -138,7 +138,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         it "returns uri with user's email" do
           expect(instance.provisioning_uri).
-            to match(%r{otpauth://totp/houdini@example.com\?secret=\w{32}})
+            to match(%r{otpauth://totp/houdini%40example.com\?secret=\w{32}})
         end
 
         it 'returns uri with issuer option' do


### PR DESCRIPTION
A couple of tests are failing because the expected string contains an `@` where the return-string is URL-escaped as `%40`.

This change fixes this issue by url-escaping the string.