### PR TITLE
Change update_attributes to update_columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Change update_attributes to update_columns [\#5](https://github.com/r6e/two_factor_authentication/pull/5)
 - Update test configuration [\#4](https://github.com/r6e/two_factor_authentication/pull/4)
 - Fix code whitespace issues [\#3](https://github.com/r6e/two_factor_authentication/pull/3)
 - Fix url encoding issue in test regex [\#2](https://github.com/r6e/two_factor_authentication/pull/2)

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,7 +101,7 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          update_attributes(
+          update_columns(
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
@@ -122,7 +122,7 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          update_columns(direct_otp: nil, direct_otp_sent_at: nil)
         end
       end
 

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -7,7 +7,7 @@ class GuestUser
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
     :second_factor_attempts_count, :totp_timestamp
 
-  def update_attributes(attrs)
+  def update_columns(attrs)
     attrs.each do |key, value|
       send(key.to_s + '=', value)
     end


### PR DESCRIPTION
There are two problems using `update_attributes`:

* It is deprecated and was removed in Rails 6.1
* It validates the record. If a user updates their OTP code on their device, but the record fails to save, the two will be out of sync. Other devise extensions skip validations for this reason, so we should too.

This change is a simple replacement of `update_attributes` with `update_columns`.