### PR TITLE
Update gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Update gems [\#6](https://github.com/r6e/two_factor_authentication/pull/6)
 - Change update_attributes to update_columns [\#5](https://github.com/r6e/two_factor_authentication/pull/5)
 - Update test configuration [\#4](https://github.com/r6e/two_factor_authentication/pull/4)
 - Fix code whitespace issues [\#3](https://github.com/r6e/two_factor_authentication/pull/3)

--- a/Gemfile
+++ b/Gemfile
@@ -9,15 +9,15 @@ rails = case rails_version
         when "master"
           {github: "rails/rails"}
         when "default"
-          "~> 5.2"
+          "~> 6.0.4.8"
         else
           "~> #{rails_version}"
         end
 
 gem "rails", rails
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
-  gem "test-unit", "~> 3.0"
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+  gem 'net-smtp', require: false
 end
 
 group :test, :development do
@@ -27,4 +27,5 @@ end
 group :test do
   gem 'rack_session_access'
   gem 'ammeter'
+  gem "test-unit", "~> 3.0"
 end

--- a/two_factor_authentication.gemspec
+++ b/two_factor_authentication.gemspec
@@ -18,14 +18,12 @@ Gem::Specification.new do |s|
     * your own sms logic
   EOF
 
-  s.rubyforge_project = "two_factor_authentication"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'rails', '>= 3.1.1'
+  s.add_runtime_dependency 'rails', '>= 6.0.4.8'
   s.add_runtime_dependency 'devise'
   s.add_runtime_dependency 'randexp'
   s.add_runtime_dependency 'rotp', '>= 4.0.0'
@@ -33,8 +31,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec-rails', '>= 3.0.1'
-  s.add_development_dependency 'capybara', '~> 2.5'
+  s.add_development_dependency 'rspec-rails', '>= 5.1.0'
+  s.add_development_dependency 'capybara', '~> 3.3'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
For ease of maintenance, we're dropping support for `Rails < 6.0.4.8`. Additionally, we're adding support for Ruby 3.

This change alters gem requirements accordingly.