### PR TITLE
Change resend_code endpoint to POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Change `resend_code` endpoint to `POST` [\#7](https://github.com/r6e/two_factor_authentication/pull/7)
 - Update gems [\#6](https://github.com/r6e/two_factor_authentication/pull/6)
 - Change update_attributes to update_columns [\#5](https://github.com/r6e/two_factor_authentication/pull/5)
 - Update test configuration [\#4](https://github.com/r6e/two_factor_authentication/pull/4)

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -6,14 +6,14 @@
 
 <p><%= flash[:notice] %></p>
 
-<%= form_tag([resource_name, :two_factor_authentication], :method => :put) do %>
+<%= form_tag([resource_name, :two_factor_authentication], method: :put) do %>
   <%= text_field_tag :code, '', autofocus: true %>
   <%= submit_tag "Submit" %>
 <% end %>
 
 <% if resource.direct_otp %>
-  <%= link_to "Resend Code", send("resend_code_#{resource_name}_two_factor_authentication_path"), action: :get %>
+  <%= link_to "Resend Code", send("resend_code_#{resource_name}_two_factor_authentication_path"), method: :post %>
 <% else %>
-<%= link_to "Send me a code instead", send("resend_code_#{resource_name}_two_factor_authentication_path"), action: :get %>
+<%= link_to "Send me a code instead", send("resend_code_#{resource_name}_two_factor_authentication_path"), method: :post %>
 <% end %>
-<%= link_to "Sign out", send("destroy_#{resource_name}_session_path"), :method => :delete %>
+<%= link_to "Sign out", send("destroy_#{resource_name}_session_path"), method: :delete %>

--- a/lib/two_factor_authentication/routes.rb
+++ b/lib/two_factor_authentication/routes.rb
@@ -4,7 +4,7 @@ module ActionDispatch::Routing
 
       def devise_two_factor_authentication(mapping, controllers)
         resource :two_factor_authentication, :only => [:show, :update, :resend_code], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
-          collection { get "resend_code" }
+          collection { post "resend_code" }
         end
       end
   end


### PR DESCRIPTION
`resend_code` creates a side-effect server-side, and so by proper idiom, should be a `POST` request. It is also potentially-sensitive, which benefits from this as well.

This changes the endpoint to `POST`. Potentially a breaking change if there are any custom overrides to the `resend_code` method.