### PR TITLE
Fix default behavior for request format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Fix default behavior for `request.format` in `handle_failed_second_factor` [\#8](https://github.com/r6e/two_factor_authentication/pull/8)
 - Change `resend_code` endpoint to `POST` [\#7](https://github.com/r6e/two_factor_authentication/pull/7)
 - Update gems [\#6](https://github.com/r6e/two_factor_authentication/pull/6)
 - Change update_attributes to update_columns [\#5](https://github.com/r6e/two_factor_authentication/pull/5)

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -20,14 +20,15 @@ module TwoFactorAuthentication
       end
 
       def handle_failed_second_factor(scope)
-        if request.format.present?
-          if request.format.html?
-            session["#{scope}_return_to"] = request.original_fullpath if request.get?
-            redirect_to two_factor_authentication_path_for(scope)
-          elsif request.format.json?
-            session["#{scope}_return_to"] = root_path(format: :html)
-            render json: { redirect_to: two_factor_authentication_path_for(scope) }, status: :unauthorized
-          end
+        if request.format&.html?
+          session["#{scope}_return_to"] = request.original_fullpath if request.get?
+          redirect_to two_factor_authentication_path_for(scope)
+        elsif request.format&.json?
+          session["#{scope}_return_to"] = root_path(format: :html)
+          render json: {
+            redirect_to: two_factor_authentication_path_for(scope),
+            authentication_type: send("current_#{scope}")&.direct_otp ? :otp : :totp
+          }, status: :unauthorized
         else
           head :unauthorized
         end

--- a/spec/rails_app/app/controllers/home_controller.rb
+++ b/spec/rails_app/app/controllers/home_controller.rb
@@ -5,6 +5,11 @@ class HomeController < ApplicationController
   end
 
   def dashboard
+    respond_to do |format|
+      format.html
+      format.json { render json: {success: true} }
+      format.xml { render xml: "<success></success>" }
+    end
   end
 
 end


### PR DESCRIPTION
If a format other than `html`, `json`, or a `nil` value is specified in the request to `handle_failed_second_factor`, there is no default behavior.

This change applies the same default as the `nil` case; returning a `HEAD` response.