### PR TITLE
Retroactively add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Add some additional tests for existing code [\#12](https://github.com/r6e/two_factor_authentication/pull/12)
 - Fix naming and namespacing issues [\#11](https://github.com/r6e/two_factor_authentication/pull/11)
 - Add support for Rails engines [\#10](https://github.com/r6e/two_factor_authentication/pull/10)
 - Change migration name to more verb-y form [\#9](https://github.com/r6e/two_factor_authentication/pull/9)

--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -76,6 +76,22 @@ feature "User of two factor authentication" do
       expect(page).to have_content("Param B is param b")
     end
 
+    scenario "is redirected to TFA when path requires authentication and works with resent code" do
+      visit dashboard_path + "?A=param%20a&B=param%20b"
+
+      expect(page).to_not have_content("Your Personal Dashboard")
+      SMSProvider.messages.clear()
+
+      click_on "Resend Code"
+      fill_in "code", with: SMSProvider.last_message.body
+      click_button "Submit"
+
+      expect(page).to have_content("Your Personal Dashboard")
+      expect(page).to have_content("You are signed in as Marissa")
+      expect(page).to have_content("Param A is param a")
+      expect(page).to have_content("Param B is param b")
+    end
+
     scenario "is locked out after max failed attempts" do
       visit user_two_factor_authentication_path
 
@@ -136,6 +152,13 @@ feature "User of two factor authentication" do
         expect(page).to have_content("Enter the code that was sent to you")
       end
 
+      scenario 'Sends OTP code by SMS' do
+        login_as user
+        SMSProvider.messages.clear()
+        visit dashboard_path
+        expect(SMSProvider.messages).not_to be_empty
+      end
+
       scenario 'TFA should be different for different users' do
         sms_sign_in
 
@@ -160,8 +183,31 @@ feature "User of two factor authentication" do
         click_button 'Submit'
       end
 
+      def sms_sign_in_with_resent_code
+        visit user_two_factor_authentication_path
+        SMSProvider.messages.clear()
+        click_on 'Resend Code'
+        fill_in 'code', with: SMSProvider.last_message.body
+        click_button 'Submit'
+      end
+
       scenario 'TFA should be unique for specific user' do
         sms_sign_in
+
+        tfa_cookie1 = get_tfa_cookie()
+
+        logout
+        reset_session!
+
+        user2 = create_user()
+        set_tfa_cookie(tfa_cookie1)
+        login_as(user2)
+        visit dashboard_path
+        expect(page).to have_content("Enter the code that was sent to you")
+      end
+
+      scenario 'TFA should be unique for specific user with resent code' do
+        sms_sign_in_with_resent_code
 
         tfa_cookie1 = get_tfa_cookie()
 

--- a/spec/requests/api_request_spec.rb
+++ b/spec/requests/api_request_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe "API request", type: :request do
+  context "when logged in" do
+    let(:user) { create_user("encrypted", email: "foo@example.com", otp_secret_key: "6iispf5cjufa4vsm") }
+
+    before do
+      sign_in user
+    end
+
+    context "with json" do
+      context "with totp authentication" do
+        it "returns 401 when path requires authentication" do
+          get "/dashboard.json"
+          expect(response.response_code).to eq(401)
+          body = JSON.parse(response.body)
+          expect(body["redirect_to"]).to eq(user_two_factor_authentication_path)
+          expect(body["authentication_type"]).to eq("totp")
+        end
+      end
+
+      context "with direct otp authentication" do
+        it "returns 401 when path requires authentication" do
+          user.update!(direct_otp: true)
+          get "/dashboard.json"
+          expect(response.response_code).to eq(401)
+          body = JSON.parse(response.body)
+          expect(body["redirect_to"]).to eq(user_two_factor_authentication_path)
+          expect(body["authentication_type"]).to eq("otp")
+        end
+      end
+
+      context "after TFA" do
+        it "returns successfully" do
+          get "/dashboard.json"
+          expect(response.response_code).to eq(401)
+          expect(JSON.parse(response.body)["redirect_to"]).to eq(user_two_factor_authentication_path)
+          totp_code = ROTP::TOTP.new(user.otp_secret_key, digits: 6).at(Time.now)
+          put "/users/two_factor_authentication", params: { code: totp_code }
+          get "/dashboard.json"
+          expect(response.response_code).to eq(200)
+          body = JSON.parse(response.body)
+          expect(body["success"]).to eq(true)
+        end
+      end
+    end
+
+    context "with xml" do
+      it "returns 401 when path requires authentication" do
+        get "/dashboard.xml"
+        expect(response.response_code).to eq(401)
+      end
+
+      context "after TFA" do
+        it "returns successfully" do
+          totp_code = ROTP::TOTP.new(user.otp_secret_key, digits: 6).at(Time.now)
+          put "/users/two_factor_authentication", params: { code: totp_code }
+          get "/dashboard.xml"
+          expect(response.response_code).to eq(200)
+          expect(response.body).to eq("<success></success>")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change retroactively adds tests for some of the code in previous PRs. The tests were a bit mixed up, so it was easier to just add them all at once.